### PR TITLE
chore: drop reverse proxy and run frontend on port 3001

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,6 +1,0 @@
-:80 {
-  reverse_proxy frontend:5000
-}
-
-# Refer to the Caddy docs for more information:
-# https://caddyserver.com/docs/caddyfile

--- a/Caddyfile.local
+++ b/Caddyfile.local
@@ -1,6 +1,0 @@
-:80 {
-  reverse_proxy frontend:5000
-}
-
-# Refer to the Caddy docs for more information:
-# https://caddyserver.com/docs/caddyfile

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -1,6 +1,0 @@
-solid-dataspace-manager.com, www.solid-dataspace-manager.com {
-  reverse_proxy frontend:5000
-}
-
-# Refer to the Caddy docs for more information:
-# https://caddyserver.com/docs/caddyfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 
 COPY . .
 
-ENV PORT=5000
-EXPOSE 5000
+ENV PORT=3001
+EXPOSE 3001
 
 CMD ["npm","start"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,25 +11,7 @@ services:
       - REACT_APP_REDIRECT_URL=${REACT_APP_REDIRECT_URL:-http://localhost}
       - REACT_APP_FOOTER_LOGOS=/assets/images/Logo_GesundesTal.png,/assets/images/Icon_GesundesTal.png
       - REACT_APP_VERSION=0.5.0
-      - PORT=5000
+      - PORT=3001
     tty: true
     ports:
-      - "${FRONTEND_PORT:-5000}:5000"
-
-  caddy:
-    image: caddy:2
-    container_name: reverse_proxy_solid_dataspace_manager
-    depends_on:
-      - frontend
-    ports:
-      - "${CADDY_HTTP_PORT:-80}:80"
-      - "${CADDY_HTTPS_PORT:-443}:443"
-    volumes:
-      - ${CADDYFILE:-./Caddyfile}:/etc/caddy/Caddyfile
-      - caddy_data:/data
-      - caddy_config:/config
-
-volumes:
-  node_modules:
-  caddy_data:
-  caddy_config:
+      - "${FRONTEND_PORT:-3001}:3001"


### PR DESCRIPTION
## Summary
- remove Caddy reverse proxy configuration
- expose React app directly on port 3001

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ac54acafb8832a875e96cf2ce53516