### PR TITLE
feat: add modal for renaming items

### DIFF
--- a/src/components/DataManager.jsx
+++ b/src/components/DataManager.jsx
@@ -32,6 +32,7 @@ import {
 import "./DataManager.css";
 import CreateFolderModal from "./CreateFolderModal";
 import ShareFileModal from "./ShareFileModal";
+import RenameItemModal from "./RenameItemModal";
 
 const noCacheFetch = (input, init = {}) =>
   solidFetch(input, {
@@ -250,6 +251,9 @@ export default function DataManager({ webId }) {
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const [shareTargetUrl, setShareTargetUrl] = useState("");
   const [shareAgents, setShareAgents] = useState([]);
+  const [renameModalOpen, setRenameModalOpen] = useState(false);
+  const [renameTargetUrl, setRenameTargetUrl] = useState("");
+  const [renameCurrentName, setRenameCurrentName] = useState("");
 
   const openCreateFolderModal = () => setFolderModalOpen(true);
 
@@ -278,8 +282,14 @@ export default function DataManager({ webId }) {
     }
   };
 
-  const renameItem = async (url) => {
-    const newName = prompt("New name?");
+  const openRenameModal = (url) => {
+    const name = decodeURIComponent(url.replace(currentUrl, "").replace(/\/$/, ""));
+    setRenameTargetUrl(url);
+    setRenameCurrentName(name);
+    setRenameModalOpen(true);
+  };
+
+  const performRename = async (url, newName) => {
     if (!newName) return;
     const newUrl = currentUrl + newName + (url.endsWith("/") ? "/" : "");
     try {
@@ -295,6 +305,13 @@ export default function DataManager({ webId }) {
     } catch {
       alert("Rename failed.");
     }
+  };
+
+  const handleRenameSubmit = async (newName) => {
+    await performRename(renameTargetUrl, newName);
+    setRenameModalOpen(false);
+    setRenameTargetUrl("");
+    setRenameCurrentName("");
   };
 
   const uploadFile = async () => {
@@ -416,7 +433,7 @@ export default function DataManager({ webId }) {
         createFolder={openCreateFolderModal}
         uploadFile={uploadFile}
         navigateTo={navigateTo}
-        renameItem={renameItem}
+        renameItem={openRenameModal}
         deleteItem={deleteItem}
         downloadFile={downloadFile}
         goBack={goBack}
@@ -437,6 +454,16 @@ export default function DataManager({ webId }) {
         onShare={handleShareItem}
         onRemove={handleRemoveShare}
         existing={shareAgents}
+      />
+      <RenameItemModal
+        show={renameModalOpen}
+        onClose={() => {
+          setRenameModalOpen(false);
+          setRenameTargetUrl("");
+          setRenameCurrentName("");
+        }}
+        onRename={handleRenameSubmit}
+        currentName={renameCurrentName}
       />
     </>
   );

--- a/src/components/RenameItemModal.jsx
+++ b/src/components/RenameItemModal.jsx
@@ -1,0 +1,57 @@
+import React, { useState, useEffect } from "react";
+import "./Modal.css";
+
+const RenameItemModal = ({ show, onClose, onRename, currentName }) => {
+  const [name, setName] = useState(currentName || "");
+
+  useEffect(() => {
+    setName(currentName || "");
+  }, [currentName]);
+
+  const handleSubmit = () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    onRename(trimmed);
+    setName("");
+    onClose();
+  };
+
+  if (!show) return null;
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-box">
+        <div className="modal-header">
+          <span className="modal-title">Rename Item</span>
+          <button className="modal-close" onClick={onClose} aria-label="Close">
+            &times;
+          </button>
+        </div>
+        <div className="modal-body">
+          <input
+            type="text"
+            className="modal-input"
+            placeholder="New name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+        <div className="modal-footer">
+          <button className="btn btn-secondary" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            className="btn btn-primary"
+            onClick={handleSubmit}
+            disabled={!name.trim()}
+          >
+            Rename
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RenameItemModal;
+


### PR DESCRIPTION
## Summary
- add RenameItemModal for renaming files and folders through modal
- integrate modal into DataManager to replace prompt-based rename

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68adb0b8d1c8832a9f0d80c3d8a722c3