### PR TITLE
feat: update urban heat app linking

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -73,10 +73,10 @@ function Sidebar() {
         </Link>
 
         <div className="sb-section">Applications</div>
-        <Link to="/web/heat" className="sb-link">
+        <a href="/smart-city-urban-heat-monitoring/" className="sb-link">
           <FontAwesomeIcon icon={faFile} />
           <span>Urban Heat Monitoring</span>
-        </Link>
+        </a>
 
         <div className="sb-section">Miscellaneous</div>
         <a

--- a/src/externalLinks.js
+++ b/src/externalLinks.js
@@ -14,9 +14,4 @@ export const externalLinks = [
     title: "Node-RED",
     url: "https://tmdt-solid-community-server.de/nodered",
   },
-  {
-    slug: "heat",
-    title: "Urban Heat Monitoring",
-    url: "https://smart-city-urban-heat-monitoring.com",
-  },
 ];


### PR DESCRIPTION
## Summary
- drop Urban Heat Monitoring from external link list
- open Urban Heat Monitoring directly via reverse proxy path

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68adb65be758832a9b4727669fcb2c9f