### PR TITLE
feat: add breadcrumb navigation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -44,6 +44,19 @@ body {
   color: var(--primary);
 }
 
+.crumb-link {
+  cursor: pointer;
+  color: var(--primary);
+}
+
+.crumb-link:hover {
+  text-decoration: underline;
+}
+
+.crumb-separator {
+  margin: 0 .25rem;
+}
+
 .primary-actions {
   display: flex;
   gap: .6rem;

--- a/src/components/DataManager.css
+++ b/src/components/DataManager.css
@@ -90,27 +90,6 @@
   color: #2e7d32;
 }
 
-.bottom-right {
-  text-align: right;
-  margin-top: 1rem;
-}
-
-.back-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: .5rem;
-  background: #757575;
-  color: white;
-  padding: .55rem 1rem;
-  font-size: .9rem;
-  border: none;
-  border-radius: 12px;
-  cursor: pointer;
-}
-
-.back-btn:hover {
-  background: #616161;
-}
 
 .file-table-container {
   height: calc(100vh - 220px);


### PR DESCRIPTION
## Summary
- replace back button with breadcrumb-style navigation in Data Manager
- style breadcrumb links for clarity

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68adc9c51a64832a9c5bcea8195f5365