### PR TITLE
Align actions column and remove file icons

### DIFF
--- a/src/components/DataManager.css
+++ b/src/components/DataManager.css
@@ -23,6 +23,7 @@
 .th-actions {
   text-align: right;
   padding-left: 0;
+  white-space: nowrap;
 }
 
 .file-table td {
@@ -35,23 +36,16 @@
   background: #fbfdff;
 }
 
-.cell-icon {
-  margin-right: .6rem;
-  font-size: 1rem;
-}
-
-.cell-icon.folder {
-  color: var(--primary);
-}
-
-.cell-icon.file {
-  color: #7b8794;
+.file-table th:first-child,
+.file-table td:first-child {
+  width: 100%;
 }
 
 .actions-cell {
   display: flex;
   justify-content: flex-end;
   gap: .25rem;
+  white-space: nowrap;
 }
 
 .icon-btn {

--- a/src/components/DataManager.jsx
+++ b/src/components/DataManager.jsx
@@ -20,7 +20,6 @@ import { fetch as solidFetch } from "@inrupt/solid-client-authn-browser";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faFolder,
-  faFileLines,
   faPlus,
   faUpload,
   faPen,
@@ -135,10 +134,6 @@ function FilesView({
                         onClick={() => isFolder && navigateTo(url)}
                         style={{ cursor: isFolder ? "pointer" : "default" }}
                       >
-                        <FontAwesomeIcon
-                          icon={isFolder ? faFolder : faFileLines}
-                          className={isFolder ? "cell-icon folder" : "cell-icon file"}
-                        />
                         {name}
                       </td>
                       <td className="actions-cell">


### PR DESCRIPTION
## Summary
- Right-align file table actions by allocating remaining width to the name column and preventing action controls from wrapping.
- Remove folder/file icons from item rows so only names display.

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68adcc349400832a94693e505a9cea3f