### PR TITLE
Fix profile document URL derivation

### DIFF
--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -119,7 +119,7 @@ export default function Profile({ webId }) {
   const [editBasics, setEditBasics] = useState(false);
   const [editContact, setEditContact] = useState(false);
 
-  const profileDocUrl = webId ? new URL("/profile/card", webId).href : "";
+  const profileDocUrl = webId ? webId.split("#")[0] : "";
 
   useEffect(() => {
     if (!webId) return;


### PR DESCRIPTION
## Summary
- derive profile document URL by removing fragment from WebID

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ae8336caac832ab2b00a0807223c4b