### PR TITLE
style: show file icons in black

### DIFF
--- a/src/components/DataManager.css
+++ b/src/components/DataManager.css
@@ -34,7 +34,14 @@
 
 .file-icon {
   margin-right: .5rem;
+}
+
+.file-icon.folder {
   color: var(--primary);
+}
+
+.file-icon.file {
+  color: #000;
 }
 
 .file-table tr:hover {

--- a/src/components/DataManager.jsx
+++ b/src/components/DataManager.jsx
@@ -133,7 +133,7 @@ function FilesView({
                       >
                         <FontAwesomeIcon
                           icon={isFolder ? faFolder : faFile}
-                          className="file-icon"
+                          className={`file-icon ${isFolder ? "folder" : "file"}`}
                         />
                         {name}
                       </td>


### PR DESCRIPTION
## Summary
- show file icons in black while leaving folder icons blue
- adjust DataManager styling to differentiate folder and file colors

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68ae8df79800832a9ee207b8726ae6b1