### PR TITLE
Add Node-RED credentials to information page

### DIFF
--- a/src/components/Info.jsx
+++ b/src/components/Info.jsx
@@ -68,6 +68,10 @@ function Info() {
           Node-RED provides real-time data integration. Flows collect data streams and store them in
           Solid Pods, keeping live information available within the dataspace.
         </p>
+        <p>
+          Use the credentials <code>solid-dataspace</code> and
+          <code>QsLumGq^BSJr^eB2xM%4</code> to sign in to the Node-RED dashboard.
+        </p>
       </div>
 
       <div className="info-section">


### PR DESCRIPTION
## Summary
- display Node-RED login credentials on the Information page

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ae90273a2c832aac80ee8604982bda