### PR TITLE
Store profile avatars directly under profile container

### DIFF
--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -230,9 +230,7 @@ export default function Profile({ webId }) {
       }
     };
 
-    const publicUrl = `${podRoot}public/`;
-    const profileUrl = `${publicUrl}profile/`;
-    await ensureContainer(publicUrl);
+    const profileUrl = `${podRoot}profile/`;
     await ensureContainer(profileUrl);
 
     const ext = file.name.split(".").pop()?.toLowerCase() || "png";


### PR DESCRIPTION
## Summary
- Save uploaded profile pictures in the `profile` container instead of `public/profile`

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68aea0664798832a85c102820eff8a89