### PR TITLE
feat: embed local semantic data catalog

### DIFF
--- a/src/externalLinks.js
+++ b/src/externalLinks.js
@@ -2,7 +2,7 @@ export const externalLinks = [
   {
     slug: "catalog",
     title: "Semantic Data Catalog",
-    url: "https://semantic-data-catalog.com",
+    url: "/semantic-data-catalog/",
   },
   {
     slug: "plasma",


### PR DESCRIPTION
## Summary
- point Semantic Data Catalog link to local instance so it can be embedded like Node-RED

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b59b380b48832a83e62ff8341f336c