### PR TITLE
Open Semantic Data Catalog in new tab

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -59,10 +59,15 @@ function Sidebar() {
         </Link>
 
         <div className="sb-section">Consume and Provide</div>
-        <Link to="/web/catalog" className="sb-link">
+        <a
+          href="/semantic-data-catalog/"
+          className="sb-link"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <FontAwesomeIcon icon={faBookOpen} />
           <span>Semantic Data Catalog</span>
-        </Link>
+        </a>
         <Link to="/web/plasma" className="sb-link">
           <FontAwesomeIcon icon={faHexagonNodes} />
           <span>PLASMA</span>

--- a/src/externalLinks.js
+++ b/src/externalLinks.js
@@ -1,10 +1,5 @@
 export const externalLinks = [
   {
-    slug: "catalog",
-    title: "Semantic Data Catalog",
-    url: "/semantic-data-catalog/",
-  },
-  {
     slug: "plasma",
     title: "PLASMA",
     url: "http://plasma.uni-wuppertal.de/modelings",


### PR DESCRIPTION
## Summary
- Open Semantic Data Catalog in a separate browser tab instead of iframe
- Remove catalog entry from external links configuration

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b69694da44832ab304e321e95e3914