### PR TITLE
Add Fuseki triple store link

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -76,6 +76,10 @@ function Sidebar() {
           <FontAwesomeIcon icon={faDatabase} />
           <span>Node-RED</span>
         </Link>
+        <Link to="/web/fuseki" className="sb-link">
+          <FontAwesomeIcon icon={faServer} />
+          <span>Fuseki</span>
+        </Link>
 
         <div className="sb-section">Applications</div>
         <Link to="/web/urban-heat-monitoring" className="sb-link">

--- a/src/externalLinks.js
+++ b/src/externalLinks.js
@@ -10,6 +10,11 @@ export const externalLinks = [
     url: "/node-red/",
   },
   {
+    slug: "fuseki",
+    title: "Fuseki",
+    url: "/fuseki/",
+  },
+  {
     slug: "urban-heat-monitoring",
     title: "Urban Heat Monitoring",
     url: "/smart-city-urban-heat-monitoring/",


### PR DESCRIPTION
## Summary
- expose Fuseki triple store as embeddable external link
- add sidebar navigation entry for Fuseki

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b6d5b20188832aae11914c3974e153