### PR TITLE
Use Font Awesome chevron in breadcrumb menu

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -55,6 +55,7 @@ body {
 
 .crumb-separator {
   margin: 0 .25rem;
+  color: var(--muted);
 }
 
 .primary-actions {

--- a/src/components/DataManager.jsx
+++ b/src/components/DataManager.jsx
@@ -26,7 +26,8 @@ import {
   faPen,
   faTrash,
   faDownload,
-  faShareNodes
+  faShareNodes,
+  faChevronRight
 } from "@fortawesome/free-solid-svg-icons";
 import "./DataManager.css";
 import CreateFolderModal from "./CreateFolderModal";
@@ -117,7 +118,12 @@ function FilesView({
         <div className="crumb">
           {crumbs.map((crumb, index) => (
             <React.Fragment key={crumb.url}>
-              {index > 0 && <span className="crumb-separator">&gt;</span>}
+              {index > 0 && (
+                <FontAwesomeIcon
+                  icon={faChevronRight}
+                  className="crumb-separator"
+                />
+              )}
               {index === crumbs.length - 1 ? (
                 <span>{crumb.name}</span>
               ) : (


### PR DESCRIPTION
## Summary
- replace plain ">" breadcrumb separator with Font Awesome chevron icon
- mute breadcrumb separator color for a cleaner look

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b7eff12730832aa1a15c713dba23fb