### PR TITLE
Remove Semantic Search references

### DIFF
--- a/src/components/Info.jsx
+++ b/src/components/Info.jsx
@@ -4,7 +4,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faTableColumns,
   faBookOpen,
-  faMagnifyingGlass,
   faHexagonNodes,
   faDatabase,
   faTemperatureHigh,
@@ -47,16 +46,6 @@ function Info() {
         <p>
           The catalog is the entry point to the dataspace. It allows providers to publish datasets and
           consumers to discover and reuse data sources hosted in Pods.
-        </p>
-      </div>
-
-      <div className="info-section">
-        <h2>
-          <FontAwesomeIcon icon={faMagnifyingGlass} /> Semantic Search
-        </h2>
-        <p>
-          Semantic Search provides a Fuseki store for querying the Semantic Data Catalog using SPARQL.
-          Use the credentials <code>admin</code> for both username and password to sign in.
         </p>
       </div>
 

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -5,7 +5,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faTableColumns,
   faBookOpen,
-  faMagnifyingGlass,
   faHexagonNodes,
   faDatabase,
   faUser,
@@ -69,10 +68,6 @@ function Sidebar() {
           <FontAwesomeIcon icon={faBookOpen} />
           <span>Semantic Data Catalog</span>
         </a>
-        <Link to="/web/semantic-search" className="sb-link">
-          <FontAwesomeIcon icon={faMagnifyingGlass} />
-          <span>Semantic Search</span>
-        </Link>
         <Link to="/web/plasma" className="sb-link">
           <FontAwesomeIcon icon={faHexagonNodes} />
           <span>PLASMA</span>

--- a/src/externalLinks.js
+++ b/src/externalLinks.js
@@ -10,11 +10,6 @@ export const externalLinks = [
     url: "/node-red/",
   },
   {
-    slug: "semantic-search",
-    title: "Semantic Search",
-    url: "http://localhost:3030/",
-  },
-  {
     slug: "urban-heat-monitoring",
     title: "Urban Heat Monitoring",
     url: "/smart-city-urban-heat-monitoring/",


### PR DESCRIPTION
## Summary
- drop Semantic Search entry from external links
- remove Semantic Search item from sidebar navigation
- clean up info page to exclude Semantic Search section

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b7f150f558832a93d3340035ae7e22