### PR TITLE
Show last modified time in Data Manager

### DIFF
--- a/src/components/DataManager.jsx
+++ b/src/components/DataManager.jsx
@@ -194,10 +194,12 @@ function FilesView({
                       </td>
                       <td>
                         {lastModified
-                          ? new Date(lastModified).toLocaleDateString("de-DE", {
+                          ? new Date(lastModified).toLocaleString("de-DE", {
                               day: "2-digit",
                               month: "2-digit",
                               year: "numeric",
+                              hour: "2-digit",
+                              minute: "2-digit",
                             })
                           : "-"}
                       </td>


### PR DESCRIPTION
## Summary
- Display both date and time in Data Manager's Last Modified column for files and folders

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b85e160190832a8ba7100e325a50eb