### PR TITLE
chore: update Solid login app name

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -32,7 +32,7 @@ const App = () => {
     await login({
       oidcIssuer: issuer,
       redirectUrl: window.location.href,
-      clientName: "Solid Data Manager",
+      clientName: "Solid Dataspace",
     });
   };
 


### PR DESCRIPTION
## Summary
- use "Solid Dataspace" as client name for Solid authentication

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba80907b04832a8f2bc2c4a611d075