### PR TITLE
Rename app to Solid Dataspace Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Getting Started with Create React App
+# Solid Dataspace Manager
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+Solid Dataspace Manager is a web application for managing data in Solid Pods and authenticating with Solid.
 
 ## Available Scripts
 
@@ -8,63 +8,18 @@ In the project directory, you can run:
 
 ### `npm start`
 
-Runs the app in the development mode.\
+Runs the app in development mode.
 Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
-
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
 
 ### `npm test`
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+Runs the test suite once.
 
 ### `npm run build`
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+Builds the app for production to the `build` folder.
 
 ### `npm run eject`
 
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
+Ejects the build configuration. This is a one-way operation.
 
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Solid Dataspace Manager web application"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Solid Dataspace Manager</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Solid Dataspace Manager",
+  "name": "Solid Dataspace Manager",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ const App = () => {
   const [sessionActive, setSessionActive] = useState(false);
 
   useEffect(() => {
-    document.title = "Solid Dataspace";
+    document.title = "Solid Dataspace Manager";
     handleIncomingRedirect({ restorePreviousSession: true }).then(() => {
       const session = getDefaultSession();
       if (session.info.isLoggedIn) {
@@ -32,7 +32,7 @@ const App = () => {
     await login({
       oidcIssuer: issuer,
       redirectUrl: window.location.href,
-      clientName: "Solid Dataspace",
+      clientName: "Solid Dataspace Manager",
     });
   };
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -11,6 +11,6 @@ import App from "./App";
 
 test("renders login screen", () => {
   render(<App />);
-  const title = screen.getByText(/Solid Dataspace Connector/i);
+  const title = screen.getByText(/Solid Dataspace Manager/i);
   expect(title).toBeInTheDocument();
 });

--- a/src/components/Info.jsx
+++ b/src/components/Info.jsx
@@ -21,7 +21,7 @@ function Info() {
         <div />
       </div>
       <p className="info-intro">
-        Solid Dataspace is a prototype dataspace built on Solid, the decentralised data platform
+        Solid Dataspace Manager is a prototype dataspace built on Solid, the decentralised data platform
         initiated by web inventor Tim Berners-Lee. Solid lets individuals store information in personal
         online data stores called Pods that they control. Using open standards for authentication and
         data interchange, Pods allow people to decide where their data lives, who can access it, and to
@@ -92,7 +92,7 @@ function Info() {
           PLASMA adds semantic annotations before datasets are published in the Semantic Data Catalog.
           People manage their Pods through the Data Manager and Profile Manager, while applications such
           as Urban Heat Monitoring reuse the catalogued resources. Together these components form the
-          Solid Dataspace.
+          Solid Dataspace Manager.
         </p>
       </div>
     </div>

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -21,7 +21,7 @@ export default function LoginScreen({ onLogin }) {
             <FontAwesomeIcon icon={faLock} />
           </div>
           <div>
-            <div className="login-hero-title">Solid Dataspace Connector</div>
+            <div className="login-hero-title">Solid Dataspace Manager</div>
             <div className="login-hero-sub">Choose your Solid Pod provider</div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- rename application branding and Solid client name to "Solid Dataspace Manager"
- update login screen, info page, and PWA metadata to new name
- replace template documentation with project-specific README

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba89d24a08832ab6e3ce5e1bfd3228