### PR TITLE
Create reusable Solid session

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { getDefaultSession, login, handleIncomingRedirect } from "@inrupt/solid-client-authn-browser";
+import session, { restoreSession } from "./solidSession";
 import "./App.css";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Sidebar from "./components/Sidebar";
@@ -15,8 +15,7 @@ const App = () => {
 
   useEffect(() => {
     document.title = "Solid Dataspace Manager";
-    handleIncomingRedirect({ restorePreviousSession: true }).then(() => {
-      const session = getDefaultSession();
+    restoreSession().then(() => {
       if (session.info.isLoggedIn) {
         const w = session.info.webId;
         if (w) {
@@ -29,7 +28,7 @@ const App = () => {
 
   const loginToSolid = async (issuer) => {
     if (!issuer) return;
-    await login({
+    await session.login({
       oidcIssuer: issuer,
       redirectUrl: window.location.href,
       clientName: "Solid Dataspace Manager",

--- a/src/components/DataManager.jsx
+++ b/src/components/DataManager.jsx
@@ -16,7 +16,7 @@ import {
   getAgentResourceAccessAll,
   saveAclFor,
 } from "@inrupt/solid-client";
-import { fetch as solidFetch } from "@inrupt/solid-client-authn-browser";
+import session from "../solidSession";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faFolder,
@@ -37,7 +37,7 @@ import AlertModal from "./AlertModal";
 import DeleteConfirmModal from "./DeleteConfirmModal";
 
 const noCacheFetch = (input, init = {}) =>
-  solidFetch(input, {
+  session.fetch(input, {
     ...init,
     cache: "no-store",
     headers: { ...(init.headers || {}), "Cache-Control": "no-cache" }

--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -16,7 +16,7 @@ import {
   overwriteFile,
   createContainerAt,
 } from "@inrupt/solid-client";
-import { fetch } from "@inrupt/solid-client-authn-browser";
+import session from "../solidSession";
 import { VCARD, FOAF } from "@inrupt/vocab-common-rdf";
 import "./Profile.css";
 import AlertModal from "./AlertModal";
@@ -146,7 +146,7 @@ export default function Profile({ webId }) {
     (async () => {
       try {
         setLoading(true);
-        const ds = await getSolidDataset(profileDocUrl, { fetch });
+        const ds = await getSolidDataset(profileDocUrl, { fetch: session.fetch });
         setDataset(ds);
         let me = getThing(ds, webId) || getThingAll(ds).find((t) => t.url === webId);
         if (!me) me = createThing({ url: webId });
@@ -206,7 +206,7 @@ export default function Profile({ webId }) {
     (async () => {
       try {
         if (!photoIri) { setPhotoSrc(""); return; }
-        const res = await fetch(photoIri);
+        const res = await session.fetch(photoIri);
         if (!res.ok) throw new Error(`Avatar ${res.status}`);
         const blob = await res.blob();
         objectUrl = URL.createObjectURL(blob);
@@ -228,10 +228,10 @@ export default function Profile({ webId }) {
 
     const ensureContainer = async (containerUrl) => {
       try {
-        await getSolidDataset(containerUrl, { fetch });
+        await getSolidDataset(containerUrl, { fetch: session.fetch });
       } catch (e) {
         if (e?.statusCode === 404 || e?.response?.status === 404) {
-          await createContainerAt(containerUrl, { fetch });
+          await createContainerAt(containerUrl, { fetch: session.fetch });
         } else {
           throw e;
         }
@@ -245,7 +245,7 @@ export default function Profile({ webId }) {
     const targetUrl = `${profileUrl}avatar-${Date.now()}.${ext}`;
     await overwriteFile(targetUrl, file, {
       contentType: file.type || guessContentType(file.name, "image/*"),
-      fetch,
+      fetch: session.fetch,
     });
     return targetUrl;
   };
@@ -288,7 +288,7 @@ export default function Profile({ webId }) {
       }
 
       ds = setThing(ds, me);
-      await saveSolidDatasetAt(profileDocUrl, ds, { fetch });
+      await saveSolidDatasetAt(profileDocUrl, ds, { fetch: session.fetch });
 
       setDataset(ds);
       setProfileThing(me);

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -13,7 +13,7 @@ import {
   faFile,
   faServer
 } from "@fortawesome/free-solid-svg-icons";
-import { logout } from "@inrupt/solid-client-authn-browser";
+import session from "../solidSession";
 import "./Sidebar.css";
 
 function Sidebar() {
@@ -22,7 +22,7 @@ function Sidebar() {
 
   const handleLogout = async () => {
     try {
-      await logout();
+      await session.logout();
       window.location.href = "/";
     } catch (e) {
       console.error("Logout failed:", e);

--- a/src/solidSession.js
+++ b/src/solidSession.js
@@ -1,0 +1,13 @@
+import { Session } from "@inrupt/solid-client-authn-browser";
+
+const session = new Session({
+  clientName: "Solid Dataspace Manager",
+  sessionId: "dataspace-manager",
+});
+
+export async function restoreSession() {
+  await session.handleIncomingRedirect({ restorePreviousSession: true });
+  return session;
+}
+
+export default session;


### PR DESCRIPTION
## Summary
- add shared `session` wrapper and `restoreSession` helper
- replace direct authn-browser imports with shared session usage

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bbc9aee594832a9783ca61adaa63e2